### PR TITLE
Update pobfrontend to new fork with scaling support

### DIFF
--- a/community.pathofbuilding.PathOfBuilding.yml
+++ b/community.pathofbuilding.PathOfBuilding.yml
@@ -69,7 +69,7 @@ modules:
       - type: git
         url: https://github.com/ernstp/pobfrontend.git
         branch: qt6
-        commit: 7821222df1e4d8a0173a467ba2877366cec3e2cc
+        commit: 9faa19aa362f975737169824c1578d5011487c18
 
   - name: start-script
     buildsystem: simple


### PR DESCRIPTION
I setup my own fork of pobfrontend to manage patches easier.

Includes this new commit: https://github.com/ernstp/pobfrontend/commit/5fa9fb714bf29f38436dd0164227f8622a94925c