### PR TITLE
Remove branch in manifest

### DIFF
--- a/community.pathofbuilding.PathOfBuilding.yml
+++ b/community.pathofbuilding.PathOfBuilding.yml
@@ -68,7 +68,6 @@ modules:
     sources:
       - type: git
         url: https://github.com/ernstp/pobfrontend.git
-        branch: qt6
         commit: 9faa19aa362f975737169824c1578d5011487c18
 
   - name: start-script


### PR DESCRIPTION
noticed in #102 that the build bot gets stuck on this lint error. Tested by building locally, also noticed that the dkjson source is flaky.

closes #101 